### PR TITLE
Use HardwareSerial by default for now, and adjust the baud rate used

### DIFF
--- a/Libraries/SnakeRobotLibrary/CommandParser.cpp
+++ b/Libraries/SnakeRobotLibrary/CommandParser.cpp
@@ -40,6 +40,7 @@ int CommandParser::getTokenFromStream(char* readBuf, int READ_BUF_LENGTH, int re
 	  else
 	  {
 		  char thisChar = this->inputStream->read();
+      this->inputStream->write(thisChar);
 
 		  if (isspace(thisChar))
 		  {
@@ -114,6 +115,8 @@ bool CommandParser::readToCommandEnd(bool* serialEnded)
 
 void CommandParser::processCurrentCommand()
 {
+  this->inputStream->print(F("[END]\n"));
+  
 	if (this->foundCommand != NULL)
 	{
 		(*(this->foundCommand->commandHandler))(this->paramBuf, this->paramIndex);

--- a/Serpentine/Serpentine12New/Serpentine12New.ino
+++ b/Serpentine/Serpentine12New/Serpentine12New.ino
@@ -15,7 +15,7 @@ of a snake robot with 12 servos
 #define USE_IMMEDIATE_COMMAND
 
 // Note: The USE_SERIAL_COMMANDS option is required to use this option
-#define USE_SOFTWARE_SERIAL
+// #define USE_SOFTWARE_SERIAL
 
 #include <Servo.h>
 
@@ -36,7 +36,7 @@ SoftwareSerial commandSoftSerial(A2, A3);
 
   #else
     #define commandSerial Serial
-    #define COMMAND_SERIAL_BAUD_RATE 115200
+    #define COMMAND_SERIAL_BAUD_RATE 38400
   #endif
 #include <CommandParser.h>
 #endif


### PR DESCRIPTION
Switched the Arduino sketch to use HardwareSerial by default for now and adjust the baud rate used. This was done after testing found reliability problems with SoftwareSerial and the higher HardwareSerial baud rate; more testing and modifications will be necessary.